### PR TITLE
Added tags method to the builder so that setting tags is easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+.idea

--- a/src/main/java/com/rebuy/consul/ConsulServiceBuilder.java
+++ b/src/main/java/com/rebuy/consul/ConsulServiceBuilder.java
@@ -71,9 +71,13 @@ public class ConsulServiceBuilder
         return new ConsulService(buildClient(), buildService());
     }
 
-    public List<String> tags()
-    {
+    public List<String> tags() {
         return tags;
+    }
+
+    public void tags(List<String> tags)
+    {
+        this.tags.addAll(tags);
     }
 
     public ConsulServiceBuilder tag(String tag)

--- a/src/test/java/com/rebuy/consul/ConsulServiceBuilderTest.java
+++ b/src/test/java/com/rebuy/consul/ConsulServiceBuilderTest.java
@@ -5,6 +5,9 @@ import com.ecwid.consul.v1.agent.model.NewService;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 public class ConsulServiceBuilderTest
@@ -66,7 +69,7 @@ public class ConsulServiceBuilderTest
     }
 
     @Test
-    public void build_should_generate_propper_object() {
+    public void build_should_generate_proper_object() {
         ConsulService service = builder.build();
         assertNotNull(service);
         assertNotNull(service.client);
@@ -79,5 +82,14 @@ public class ConsulServiceBuilderTest
         assertTrue(service.service.getTags().contains("bish"));
         assertTrue(service.service.getTags().contains("bash"));
         assertTrue(service.service.getTags().contains("bosh"));
+    }
+
+    @Test
+    public void builder_should_contain_initial_and_added_tags() {
+        final List<String> tags = Arrays.asList("tag1", "tag2", "tag3");
+
+        builder.tags(tags);
+
+        assertEquals(builder.tags().size(), 6);
     }
 }


### PR DESCRIPTION
@rebuy-de/prp-consul-java-client 

Small builder method to go from:

```java
NewService buildService()
    {
        List&lt;String&gt; tags = Arrays.of("bish", "bash", bosh");
        builder = new ConsulServiceBuilder()
            .agent("my-host")
            .name("my-service")
            .checkInterval("20s")
            .port(1337);
        tags.forEach(builder::tag);
    }
```

which breaks the fluid builder. To:

```java
NewService buildService()
    {
        List&lt;String&gt; tags = Arrays.of("bish", "bash", bosh");
        builder = new ConsulServiceBuilder()
            .agent("my-host")
            .name("my-service")
            .checkInterval("20s")
            .port(1337)
            .tags(tags);
    }
```